### PR TITLE
feat: add RowScanner interface for custom database row mapping

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -31,6 +31,25 @@ var (
 	timeType = reflect.TypeOf((*time.Time)(nil)).Elem()
 )
 
+// bindWithResultMap maps sql.Rows to a destination value using the specified ResultMap.
+// It serves as the core binding function for all mapping operations in the package.
+//
+// Parameters:
+//   - rows: The source sql.Rows to map from. Must not be nil.
+//   - v: The destination value to map to. Must be a pointer and not nil.
+//   - resultMap: The mapping strategy to use. If nil, a default mapper will be selected
+//     based on the destination type (SingleRowResultMap for struct, MultiRowsResultMap for slice).
+//
+// The function follows this process:
+// 1. Validates input parameters
+// 2. Checks if the destination implements RowScanner for custom mapping
+// 3. Falls back to reflection-based mapping using the provided or default ResultMap
+//
+// Returns an error if:
+//   - The destination is nil (ErrNilDestination)
+//   - The rows parameter is nil (ErrNilRows)
+//   - The destination is not a pointer (ErrPointerRequired)
+//   - Any error occurs during the mapping process
 func bindWithResultMap(rows *sql.Rows, v any, resultMap ResultMap) error {
 	if v == nil {
 		return ErrNilDestination
@@ -38,13 +57,17 @@ func bindWithResultMap(rows *sql.Rows, v any, resultMap ResultMap) error {
 	if rows == nil {
 		return ErrNilRows
 	}
-	// get reflect.Value of v
+	// Try custom row scanning if the destination implements RowScanner
+	if rowScanner, ok := v.(RowScanner); ok {
+		return rowScanner.ScanRows(rows)
+	}
 	rv := reflect.ValueOf(v)
 
 	if rv.Kind() != reflect.Ptr {
 		return ErrPointerRequired
 	}
-	// get default mapper
+
+	// Select default mapper if none provided
 	if resultMap == nil {
 		if kd := reflect.Indirect(rv).Kind(); kd == reflect.Slice {
 			resultMap = MultiRowsResultMap{}
@@ -52,6 +75,7 @@ func bindWithResultMap(rows *sql.Rows, v any, resultMap ResultMap) error {
 			resultMap = SingleRowResultMap{}
 		}
 	}
+	// Perform the actual mapping
 	return resultMap.MapTo(rv, rows)
 }
 
@@ -74,6 +98,25 @@ func BindWithResultMap[T any](rows *sql.Rows, resultMap ResultMap) (result T, er
 }
 
 // Bind sql.Rows to given entity with default mapper
+// Example usage of the binder package
+//
+// Example_bind shows how to use the Bind function:
+//
+//	type User struct {
+//	    ID   int    `column:"id"`
+//	    Name string `column:"name"`
+//	}
+//
+//	rows, err := db.Query("SELECT id, name FROM users")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer rows.Close()
+//
+//	user, err := Bind[[]User](rows)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 func Bind[T any](rows *sql.Rows) (result T, err error) {
 	return BindWithResultMap[T](rows, nil)
 }
@@ -87,6 +130,24 @@ func Bind[T any](rows *sql.Rows) (result T, err error) {
 //
 // Bind is more flexible; you can use it to bind a single row to a struct, a slice of structs, or a slice of any type.
 // However, if you are sure that the result will be a slice, you can use List. It could be faster than Bind.
+//
+// Example_list shows how to use the List function:
+//
+//	type User struct {
+//	    ID   int    `column:"id"`
+//	    Name string `column:"name"`
+//	}
+//
+//	rows, err := db.Query("SELECT id, name FROM users")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer rows.Close()
+//
+//	users, err := List[User](rows)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 func List[T any](rows *sql.Rows) (result []T, err error) {
 	var multiRowsResultMap MultiRowsResultMap
 
@@ -98,6 +159,6 @@ func List[T any](rows *sql.Rows) (result []T, err error) {
 		multiRowsResultMap.New = func() reflect.Value { return reflect.ValueOf(new(T)) }
 	}
 
-	err = multiRowsResultMap.MapTo(reflect.ValueOf(&result), rows)
-	return result, err
+	err = bindWithResultMap(rows, &result, multiRowsResultMap)
+	return
 }

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 eatmoreapple
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package juice
+
+import "database/sql"
+
+// RowScanner is an interface that provides a custom mechanism for mapping database rows
+// to Go structures. It serves as an extension point in the data binding system,
+// allowing implementers to override the default reflection-based mapping behavior.
+//
+// When a type implements this interface, the binding system will detect it during
+// the mapping process and delegate the row scanning responsibility to the implementation.
+// This gives complete control over how database values are mapped to the target structure.
+//
+// Use cases:
+// - Custom mapping logic for complex database schemas or legacy systems
+// - Performance optimization by eliminating reflection overhead
+// - Special data type handling (e.g., JSON, XML, custom database types)
+// - Complex data transformations during the mapping process
+// - Implementation of caching or lazy loading strategies
+//
+// Example implementation:
+//
+//	func (u *User) ScanRows(rows *sql.Rows) error {
+//	    return rows.Scan(&u.ID, &u.Name, &u.Email)
+//	}
+//
+// The implementation must ensure proper handling of NULL values and return
+// appropriate errors if the scanning process fails.
+type RowScanner interface {
+	ScanRows(rows *sql.Rows) error
+}


### PR DESCRIPTION
Add RowScanner interface to provide a flexible mechanism for custom database 
row scanning. This interface allows users to:
- Implement custom mapping logic for complex schemas
- Optimize performance by avoiding reflection
- Handle special data types and transformations
- Support caching and lazy loading strategies